### PR TITLE
Create output directory for chunks and final transcription

### DIFF
--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -39,7 +39,12 @@ func getDuration(filePath string) (float64, error) {
 }
 
 // Split the audio file into parts using ffmpeg
-func splitAudioFile(inputPath string, outputPattern string) error {
+func splitAudioFile(inputPath string, outputPattern string, outputDir string) error {
+	// Create the output directory if it does not exist
+	if err := os.MkdirAll(outputDir, os.ModePerm); err != nil {
+		return fmt.Errorf("error creating directory: %v", err)
+	}
+
 	cmd := exec.Command("ffmpeg", "-i", inputPath, "-f", "segment",
 		"-segment_time", "600", "-c", "copy", outputPattern)
 	return cmd.Run()


### PR DESCRIPTION
Create a directory for chunks and final transcription named the same as the transcription file but without the extension.

* **main.go**
  - Extract the base name of the input file without extension.
  - Create a directory with the base name.
  - Set `outputPattern` to save chunks in the newly created directory.
  - Save the final transcription and combined JSON in the newly created directory.

* **whisper/whisper.go**
  - Update `splitAudioFile` function to accept the output directory as a parameter.
  - Update `splitAudioFile` function to create the output directory if it does not exist.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LeopoldFortunatus/whisper-cli/pull/3?shareId=c3cafadc-6b6b-46ec-9d9c-1eb2dca4f75b).