### PR TITLE
Create folder for chunks and final transcription

### DIFF
--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -42,6 +43,13 @@ func SplitAudioFile(
 	inputPath string,
 	outputPattern string,
 ) error {
+	// Create the output directory if it doesn't exist
+	outputDir := filepath.Dir(outputPattern)
+	err := os.MkdirAll(outputDir, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("error creating output directory: %v", err)
+	}
+
 	cmd := exec.Command("ffmpeg", "-i", inputPath, "-f", "segment",
 		"-segment_time", "600", "-c", "copy", outputPattern)
 	return cmd.Run()


### PR DESCRIPTION
Add functionality to create a folder for chunks and final transcription named the same as the transcription file but without the extension.

* **main.go**
  - Add code to create a folder named the same as the transcription file but without the extension.
  - Update the `outputPattern` to save chunks in the created folder.
  - Update the final transcription file path to save in the created folder.

* **whisper/whisper.go**
  - Update the `SplitAudioFile` function to create the folder if it doesn't exist.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LeopoldFortunatus/whisper-cli/pull/4?shareId=14f103c4-fcb0-499f-97cb-0aa0faa3db7e).